### PR TITLE
Make `oled_task_user` override correctly

### DIFF
--- a/qmk/ladis/keymaps/default/keymap.c
+++ b/qmk/ladis/keymaps/default/keymap.c
@@ -61,7 +61,7 @@ static void render_logo(void) {
 }
 
 
-void oled_task_user(void) {
+bool oled_task_user(void) {
   if (is_keyboard_master()) {
     // If you want to put your image on the master side, put your function call here:
     render_logo();
@@ -69,4 +69,6 @@ void oled_task_user(void) {
     // And if you want to put your image on the slave side, put it here instead:
     render_logo();
   }
+
+  return false;
 }


### PR DESCRIPTION
In QMK 0.15.12 `oled_task_user` has been changed from type void to type
bool. This commit updates the keymap code accordingly.

Changelog: https://docs.qmk.fm/#/ChangeLog/20211127?id=oled-task-refactor
Pull Request: qmk/qmk_firmware#14864